### PR TITLE
Fix validation loop in wifi_manager

### DIFF
--- a/Smart Irigation Systtem/src/wifi_manager.cpp
+++ b/Smart Irigation Systtem/src/wifi_manager.cpp
@@ -4,12 +4,17 @@
 #include <ArduinoJson.h>
 #include <WiFi.h>
 #include <HTTPClient.h>
+#include <ctype.h>
 #include "config.h"
 
 WiFiManagerESP::WiFiManagerESP() : server(80), apMode(false) {}
 bool WiFiManagerESP::validateInput(const String& s, const String& p) {
     if (s.length() < 2 || s.length() > 32) return false;
-    for (char c : s) if (!isalnum(c) && c != '-' && c != '_' && c != '.') return false;
+    for (size_t i = 0; i < s.length(); i++) {
+        char c = s[i];
+        if (!isalnum(c) && c != '-' && c != '_' && c != '.')
+            return false;
+    }
     if (p.length() < 4 || p.length() > 63) return false;
     return true;
 }


### PR DESCRIPTION
## Summary
- add `ctype.h` include to wifi_manager
- use index-based loop for SSID validation

## Testing
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852b6db60dc832c8fb02001d4ec4d64