### PR TITLE
Fix workspace path

### DIFF
--- a/Smart Irigation Systtem/ESP32.code-workspace
+++ b/Smart Irigation Systtem/ESP32.code-workspace
@@ -1,7 +1,7 @@
 {
 	"folders": [
 		{
-			"path": "E:/Aplicatie/ESP32"
+			"path": "."
 		},
 		{
 			"name": "Smart Irigation Systtem",


### PR DESCRIPTION
## Summary
- fix workspace folder path to a relative path

## Testing
- `grep -R "E:/Aplicatie" -n`


------
https://chatgpt.com/codex/tasks/task_e_6852b6e3cec0832c9d0faddfbd9b3ea9