### PR TITLE
Remove unused buffer backup methods

### DIFF
--- a/Smart Irigation Systtem/src/buffer_manager.cpp
+++ b/Smart Irigation Systtem/src/buffer_manager.cpp
@@ -45,15 +45,3 @@ void BufferManager::flushToServer(bool(*sendFn)(const String&)) {
     SPIFFS.remove("/buffer.json");
 }
 bool BufferManager::hasSpace() { return countLines() < MAX_BUFFER_LINES; }
-void BufferManager::backupBuffer() {
-    File file = SPIFFS.open("/buffer.json", FILE_READ);
-    File backup = SPIFFS.open("/buffer.bak", FILE_WRITE);
-    while (file && file.available()) backup.println(file.readStringUntil('\n'));
-    file.close(); backup.close();
-}
-void BufferManager::restoreBuffer() {
-    File file = SPIFFS.open("/buffer.bak", FILE_READ);
-    File mainf = SPIFFS.open("/buffer.json", FILE_WRITE);
-    while (file && file.available()) mainf.println(file.readStringUntil('\n'));
-    file.close(); mainf.close();
-}

--- a/Smart Irigation Systtem/src/buffer_manager.h
+++ b/Smart Irigation Systtem/src/buffer_manager.h
@@ -9,6 +9,4 @@ public:
     int countLines();
     void enforceLimit();
     bool hasSpace();
-    void backupBuffer();
-    void restoreBuffer();
 };


### PR DESCRIPTION
## Summary
- clean up `BufferManager` by removing `backupBuffer` and `restoreBuffer`

## Testing
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852b6e8168c832c96006cb8fa8990c8